### PR TITLE
Add back all country support for validating VAT numbers

### DIFF
--- a/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/Customer/ISS/CheckVatNumberTests.cs
+++ b/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/Customer/ISS/CheckVatNumberTests.cs
@@ -1,0 +1,115 @@
+﻿using Xunit;
+
+namespace CluedIn.ExternalSearch.VatLayer.Unit.Tests.Utility.VatNumberCleaner.Customer.ISS
+{
+    /// <summary>
+    /// Checks ISS VAT numbers
+    /// Developers can use http://www.vatcheck.eu/vatcheck.php to validate EU VAT numbers
+    /// </summary>
+    public class CheckVatNumberTests : TestBase
+    {
+        [Theory]
+        [InlineData("GB222 5607 89")]
+        [InlineData("GB776 5310 13")]
+        [InlineData("BE0888533955")]
+        [InlineData("GB417 1157 75")]
+        [InlineData("GB702 4610 79")]
+        [InlineData("GB272 7221 11")]
+        [InlineData("GB735 1406 54")]
+        [InlineData("GB168 8372 61")]
+        [InlineData("GB747 8798 54")]
+        [InlineData("SE556410328001")]
+        [InlineData("GB108 3046 44")]
+        [InlineData("DK10161614")]
+        [InlineData("GB945 7518 87")]
+        [InlineData("FR02453829079")]
+        [InlineData("GB503 1018 15")]
+        [InlineData("NL802353794B01")]
+        [InlineData("GB923 4281 36")]
+        [InlineData("GB731 7507 42")]
+        [InlineData("GB883 8175 78")]
+        [InlineData("GB597 2654 89")]
+        [InlineData("GB704 2101 01")]
+        [InlineData("GB108 2409 39")]
+        [InlineData("GB703 5643 53")]
+        [InlineData("GB202 1441 76")]
+        [InlineData("GB724 6179 27")]
+        [InlineData("GB439 4758 08")]
+        [InlineData("GB336 3492 51")]
+        [InlineData("GB135 5557 06")]
+        [InlineData("GB559 0978 89")]
+        [InlineData("GB506 6026 70")]
+        [InlineData("GB814 2577 34")]
+        [InlineData("GB108 2470 36")]
+        [InlineData("GB243 1640 91")]
+        [InlineData("GB997 3273 64")]
+        [InlineData("GB919 2934 95")]
+        [InlineData("GB892 1637 03")]
+        [InlineData("GB160 0904 45")]
+        [InlineData("GB297 9364 87")]
+        [InlineData("GB434 9713 35")]
+        [InlineData("GB494 5524 16")]
+        [InlineData("GB223 7100 10")]
+        [InlineData("GB804 1163 73")]
+        [InlineData("GB394 1212 63")]
+        [InlineData("GB178 3069 80")]
+        [InlineData("GB239 2074 64")]
+        [InlineData("GB801 7806 45")]
+        [InlineData("GB732 3615 53")]
+        [InlineData("GB298 4484 96")]
+        [InlineData("GB694 1366 12")]
+        [InlineData("GB223 4728 76")]
+        [InlineData("GB670 7557 13")]
+        [InlineData("GB989 1122 90")]
+        [InlineData("GB795 9294 54")]
+        [InlineData("GB746 6441 14")]
+        [InlineData("GB823 8535 19")]
+        [InlineData("GB772 1252 45")]
+        [InlineData("GB310 0319 75")]
+        public void ReturnsValidVatNumber(string vatNumber)
+        {
+            Assert.NotEmpty(
+                Sut.CheckVATNumber(vatNumber));
+        }
+
+        [Theory]
+        [InlineData("GB000 0000 11")]
+        [InlineData("GB000 0000 12")]
+        [InlineData("GB000 0000 01")]
+        [InlineData("GB000 0000 05")]
+        [InlineData("GB000 0000 23")]
+        [InlineData("GB000 0000 31")]
+        [InlineData("GB000 0000 17")]
+        [InlineData("GB000 0000 02")]
+        [InlineData("GB000 0000 06")]
+        [InlineData("GB000 0000 27")]
+        [InlineData("GB000 0000 00")]
+        [InlineData("GB000 0000 03")]
+        [InlineData("GB000 0000 25")]
+        [InlineData("GB000 0000 08")]
+        [InlineData("GB000 0000 09")]
+        [InlineData("GB000 0000 07")]
+        [InlineData("GB000 0000 04")]
+        [InlineData("GB000 0000 10")]
+        [InlineData("GB000 0000 21")]
+        [InlineData("GB000 0000 14")]
+        [InlineData("GB000 0000 15")]
+        [InlineData("GB000 0000 28")]
+        [InlineData("GB000 0000 19")]
+        [InlineData("GB000 0000 24")]
+        [InlineData("GB000 0000 26")]
+        [InlineData("GB000 0000 13")]
+        [InlineData("GB000 0000 16")]
+        [InlineData("GB000 0000 18")]
+        [InlineData("GB000 0000 20")]
+        [InlineData("GB000 0000 22")]
+        [InlineData("GB000 0000 29")]
+        [InlineData("GB000 0000 54")]
+        [InlineData("GB505 4652 55")]
+        public void ReturnsEmptyStringForInvalidVatNumber(string vatNumber)
+        {
+            Assert.Empty(
+                Sut.CheckVATNumber(vatNumber));
+        }
+    }
+}

--- a/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/TestBase.cs
+++ b/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/TestBase.cs
@@ -1,0 +1,12 @@
+﻿namespace CluedIn.ExternalSearch.VatLayer.Unit.Tests.Utility.VatNumberCleaner
+{
+    public abstract class TestBase
+    {
+        protected readonly Providers.VatLayer.Utility.VatNumberCleaner Sut;
+
+        protected TestBase()
+        {
+            Sut = new Providers.VatLayer.Utility.VatNumberCleaner();
+        }
+    }
+}

--- a/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/VatNumberCleanerTests.cs
+++ b/test/unit/ExternalSearch.VatLayer.Unit.Tests/Utility/VatNumberCleaner/VatNumberCleanerTests.cs
@@ -1,16 +1,14 @@
-﻿using CluedIn.ExternalSearch.Providers.VatLayer.Utility;
+﻿using Xunit;
 
-using Xunit;
-
-namespace CluedIn.ExternalSearch.VatLayer.Unit.Tests.Utility
+namespace CluedIn.ExternalSearch.VatLayer.Unit.Tests.Utility.VatNumberCleaner
 {
-    public class VatNumberCleanerTests
+    public class VatNumberCleanerTests : TestBase
     {
-        private readonly VatNumberCleaner _sut;
+        private readonly Providers.VatLayer.Utility.VatNumberCleaner _sut;
 
         public VatNumberCleanerTests()
         {
-            _sut = new VatNumberCleaner();
+            _sut = new Providers.VatLayer.Utility.VatNumberCleaner();
         }
 
         [Theory]
@@ -275,103 +273,6 @@ namespace CluedIn.ExternalSearch.VatLayer.Unit.Tests.Utility
         public void TestEsbCheckDigit2(string vatNumber)
         {
             Assert.True(_sut.ESVATCheckDigit(vatNumber));
-        }
-
-        [Theory]
-        [InlineData("GB000 0000 11")]
-        [InlineData("GB000 0000 12")]
-        [InlineData("GB222 5607 89")]
-        [InlineData("GB776 5310 13")]
-        [InlineData("BE0888533955" )]
-        [InlineData("GB417 1157 75")]
-        [InlineData("GB702 4610 79")]
-        [InlineData("GB272 7221 11")]
-        [InlineData("GB000 0000 01")]
-        [InlineData("GB735 1406 54")]
-        [InlineData("GB000 0000 05")]
-        [InlineData("GB168 8372 61")]
-        [InlineData("GB000 0000 23")]
-        [InlineData("GB747 8798 54")]
-        [InlineData("SE556410328001")]
-        [InlineData("GB108 3046 44")]
-        [InlineData("DK10161614")]
-        [InlineData("GB945 7518 87")]
-        [InlineData("GB000 0000 31")]
-        [InlineData("FR02453829079")]
-        [InlineData("GB503 1018 15")]
-        [InlineData("NL802353794B01")]
-        [InlineData("GB000 0000 17")]
-        [InlineData("GB923 4281 36")]
-        [InlineData("GB731 7507 42")]
-        [InlineData("GB000 0000 02")]
-        [InlineData("GB883 8175 78")]
-        [InlineData("GB000 0000 06")]
-        [InlineData("GB000 0000 27")]
-        [InlineData("GB000 0000 00")]
-        [InlineData("GB000 0000 03")]
-        [InlineData("GB597 2654 89")]
-        [InlineData("GB704 2101 01")]
-        [InlineData("GB000 0000 25")]
-        [InlineData("GB108 2409 39")]
-        [InlineData("GB703 5643 53")]
-        [InlineData("GB202 1441 76")]
-        [InlineData("GB724 6179 27")]
-        [InlineData("GB439 4758 08")]
-        [InlineData("GB336 3492 51")]
-        [InlineData("GB000 0000 08")]
-        [InlineData("GB135 5557 06")]
-        [InlineData("GB000 0000 09")]
-        [InlineData("GB559 0978 89")]
-        [InlineData("GB000 0000 07")]
-        [InlineData("GB000 0000 04")]
-        [InlineData("GB000 0000 10")]
-        [InlineData("GB506 6026 70")]
-        [InlineData("GB814 2577 34")]
-        [InlineData("GB000 0000 21")]
-        [InlineData("GB108 2470 36")]
-        [InlineData("GB243 1640 91")]
-        [InlineData("GB997 3273 64")]
-        [InlineData("GB919 2934 95")]
-        [InlineData("GB892 1637 03")]
-        [InlineData("GB000 0000 14")]
-        [InlineData("GB000 0000 15")]
-        [InlineData("GB160 0904 45")]
-        [InlineData("GB297 9364 87")]
-        [InlineData("GB000 0000 28")]
-        [InlineData("GB434 9713 35")]
-        [InlineData("GB494 5524 16")]
-        [InlineData("GB000 0000 19")]
-        [InlineData("GB000 0000 24")]
-        [InlineData("GB000 0000 26")]
-        [InlineData("GB223 7100 10")]
-        [InlineData("GB000 0000 13")]
-        [InlineData("GB804 1163 73")]
-        [InlineData("GB394 1212 63")]
-        [InlineData("GB178 3069 80")]
-        [InlineData("GB239 2074 64")]
-        [InlineData("GB801 7806 45")]
-        [InlineData("GB000 0000 16")]
-        [InlineData("GB000 0000 18")]
-        [InlineData("GB732 3615 53")]
-        [InlineData("GB298 4484 96")]
-        [InlineData("GB505 4652 55")]
-        [InlineData("GB694 1366 12")]
-        [InlineData("GB000 0000 20")]
-        [InlineData("GB000 0000 22")]
-        [InlineData("GB223 4728 76")]
-        [InlineData("GB670 7557 13")]
-        [InlineData("GB989 1122 90")]
-        [InlineData("GB795 9294 54")]
-        [InlineData("GB746 6441 14")]
-        [InlineData("GB000 0000 29")]
-        [InlineData("GB823 8535 19")]
-        [InlineData("GB772 1252 45")]
-        [InlineData("GB310 0319 75")]
-        [InlineData("GB000 0000 54")]
-        public void CheckIssVatNumber(string vatNumber)
-        {
-            Assert.NotEmpty(
-                _sut.CheckVATNumber(vatNumber));
         }
     }
 }


### PR DESCRIPTION
Fixes Issue #11 

Summary of changes:

- @lovrobiljeskovic has restored previously commented out support for EU countries other than France
- Added unit tests for ISS provided VAT number ranges

[European VAT number validation](http://www.vatcheck.eu/vatcheck.php) website is very useful for checking VAT numbers.