### PR TITLE
Changed "ApiToken for VatLayer must be provided." to not throw exception

### DIFF
--- a/src/VatLayerExternalSearchProvider.cs
+++ b/src/VatLayerExternalSearchProvider.cs
@@ -83,7 +83,8 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
             {
                 if (string.IsNullOrEmpty(TokenProvider?.ApiToken))
                 {
-                    throw new InvalidOperationException("ApiToken for VatLayer must be provided.");
+                    context.Log.Error(() => "ApiToken for VatLayer must be provided.");
+                    yield break;
                 }
 
                 if (!Accepts(request.EntityMetaData.EntityType))


### PR DESCRIPTION
Fixes Issue #19 

Instead of throwing exception when missing Api Token, now just logs and `yield break`'s 

Tested by forcing recrawl - error appears once for each batch of clues processed, without retry due to exception

![image](https://user-images.githubusercontent.com/8555829/79572631-7bbce880-80e7-11ea-98b4-18475ee509cc.png)
