### PR TITLE
chore: Hide constructors which confuse container

### DIFF
--- a/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
@@ -43,13 +43,13 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
             }
         }
 
-        public VatLayerExternalSearchProvider(IEnumerable<string> tokens)
+        private VatLayerExternalSearchProvider(IEnumerable<string> tokens)
             : this(true)
         {
             TokenProvider = new RoundRobinTokenProvider(tokens);
         }
 
-        public VatLayerExternalSearchProvider(IExternalSearchTokenProvider tokenProvider)
+        private VatLayerExternalSearchProvider(IExternalSearchTokenProvider tokenProvider)
             : this(true)
         {
             TokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
@@ -457,6 +457,6 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
         public Guide Guide { get; } = Constants.Guide;
         public IntegrationType Type { get; } = Constants.IntegrationType;
 
-        
+
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Castle.Windsor will pick up the first constructor which is suitable. So now it mistakenly picks `VatLayerExternalSearchProvider(IEnumerable<string> tokens)` and provides it with empty token. That's definitely not the intention and instead we want DI to use empty constructor.

I made all other constructors private, so it will for sure pick up the correct one.
