### PR TITLE
fix: Fix failed test connection due to exception

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -5,3 +5,4 @@
 
 # Fix
 - Mask and rename enricher configuration api key field
+- Fix test connection fail due to exception

--- a/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
@@ -406,7 +406,7 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
                 try
                 {
                     var content = JsonConvert.DeserializeObject<VatLayerErrorResponse>(response.Content);
-                    if (!string.IsNullOrWhiteSpace(content.Error.Type) && content.Error.Type.Equals("invalid_access_key", StringComparison.OrdinalIgnoreCase) == true)
+                    if (!string.IsNullOrWhiteSpace(content?.Error?.Type) && content.Error.Type.Equals("invalid_access_key", StringComparison.OrdinalIgnoreCase) == true)
                     {
                         return new ConnectionVerificationResult(false, $"{Constants.ProviderName} returned \"401 Unauthorized\". This could be due to an invalid API key.");
                     }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#46338](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/46338)

Although the test connection is not failing due to exception, but it still failing due to invalid vat number. Seem like there is something like "vat number renewal" or database upgrade. Not sure yet, will wait for few days a retry.

## How has it been tested? <!-- Remove if not needed -->
Manually in local

