### PR TITLE
fix: Set accepted vocabulary key as mandatory

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+# Fix
+- Set Accepted Vocabulary Key as mandatory

--- a/src/ExternalSearch.Providers.VatLayer/Constants.cs
+++ b/src/ExternalSearch.Providers.VatLayer/Constants.cs
@@ -86,7 +86,7 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
                 {
                     DisplayName = "Accepted Vocabulary Key",
                     Type = "vocabularyKeySelector",
-                    IsRequired = false,
+                    IsRequired = true,
                     Name = KeyName.AcceptedVocabKey,
                     Help = "The vocabulary key that contains the VAT numbers of companies you want to enrich (e.g., organization.vat)."
                 },


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48835](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48835)

After updating:
![image](https://github.com/user-attachments/assets/eeb91fb7-0f00-4171-a9f8-3f5ce624edd4)


## How has it been tested? <!-- Remove if not needed -->
Manually in local

