### PR TITLE
bugfix: Retry when rate limit hit

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -34,6 +34,7 @@
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <!--    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />-->
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
+    <PackageReference Update="CluedIn.Integration.PrivateServices" Version="$(_CluedIn)" />
   </ItemGroup>
   <ItemGroup Label="Global tools">
     <!--

--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -3,4 +3,4 @@
 
 # Fix
 - Set Accepted Vocabulary Key as mandatory
-- Retry when rate limit hit
+- Retry requests when rate limit is hit

--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -3,3 +3,4 @@
 
 # Fix
 - Set Accepted Vocabulary Key as mandatory
+- Retry when rate limit hit

--- a/src/ExternalSearch.Providers.VatLayer/ExternalSearch.Providers.VatLayer.csproj
+++ b/src/ExternalSearch.Providers.VatLayer/ExternalSearch.Providers.VatLayer.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
+    <PackageReference Include="CluedIn.Integration.PrivateServices" />
   </ItemGroup>
   <PropertyGroup>
     <LangVersion>preview</LangVersion>

--- a/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 
 using CluedIn.Core;
 using CluedIn.Core.Data;
@@ -13,11 +14,13 @@ using CluedIn.Core.Connectors;
 using CluedIn.ExternalSearch.Providers.VatLayer.Models;
 using CluedIn.ExternalSearch.Providers.VatLayer.Utility;
 using CluedIn.ExternalSearch.Providers.VatLayer.Vocabularies;
+using CluedIn.Integration.PrivateServices.AppContext;
 
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using RestSharp;
 using EntityType = CluedIn.Core.Data.EntityType;
+using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.ExternalSearch.Providers.VatLayer
 {
@@ -182,7 +185,13 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
         public IEnumerable<IExternalSearchQueryResult> ExecuteSearch(ExecutionContext context, IExternalSearchQuery query, IDictionary<string, object> config, IProvider provider)
         {
             var jobData = new VatLayerExternalSearchJobData(config);
-            return InternalExecuteSearch(context, query, jobData.ApiToken);
+
+            return ActionExtensions.ExecuteWithRetry(
+                () => InternalExecuteSearch(context, query, jobData.ApiToken).ToArray(),
+                retryInterval: TimeSpan.FromSeconds(1),
+                retryCount: 1000,
+                isTransient: ex => ex.IsTransient() || ex.ToString().Contains("TooManyRequests")
+            );
         }
 
         private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext context, IExternalSearchQuery query, string apiToken)
@@ -235,12 +244,20 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
                         }
                         else
                         {
+                            var content = JsonConvert.DeserializeObject<dynamic>(response.Content);
+
+                            if (content?.error?.type == "rate_limit_reached" || content?.error?.code == "106")
+                            {
+                                WaitDueToTooManyRequests(context, response);
+
+                                throw new Exception($"Too many requests - Call to VatLayer returned {content.error.type}");
+                            }
+
                             var diagnostic =
                                 $"Failed external search for Id: '{query.Id}' QueryKey: '{query.QueryKey}' - StatusCode: '{response.StatusCode}' Content: '{response.Content}'";
 
                             context.Log.LogError(diagnostic);
 
-                            var content = JsonConvert.DeserializeObject<dynamic>(response.Content);
                             if (content.error != null)
                             {
                                 throw new InvalidOperationException(
@@ -437,6 +454,17 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
             PopulateMetadata(metadata, resultItem, request);
 
             return metadata;
+        }
+
+        internal static void WaitDueToTooManyRequests(ExecutionContext executionContext, IRestResponse response)
+        {
+            var privateApplicationContext = executionContext.ApplicationContext.Container.Resolve<IPrivateApplicationContext>();
+            var lockingScope = privateApplicationContext.CreateLockingScope();
+            using (lockingScope.GetClusterWideExclusiveLockAsync($"{nameof(VatLayerExternalSearchProvider)}", TimeSpan.Zero).GetAwaiter().GetResult())
+            {
+                executionContext.Log.LogDebug($"Sleeping thread for 1000ms due to TooManyRequest response received");
+                Thread.Sleep(1000);
+            }
         }
 
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<VatLayerResponse> resultItem, IExternalSearchRequest request)

--- a/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
@@ -244,7 +244,7 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
                         }
                         else
                         {
-                            var content = JsonConvert.DeserializeObject<dynamic>(response.Content);
+                            var content = JsonConvert.DeserializeObject<dynamic>(string.IsNullOrEmpty(response?.Content) ? "{}" : response.Content);
 
                             if (content?.error?.type == "rate_limit_reached" || content?.error?.code == "106")
                             {
@@ -460,10 +460,12 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
         {
             var privateApplicationContext = executionContext.ApplicationContext.Container.Resolve<IPrivateApplicationContext>();
             var lockingScope = privateApplicationContext.CreateLockingScope();
+            var delay = TimeSpan.FromSeconds(1);
+
             using (lockingScope.GetClusterWideExclusiveLockAsync($"{nameof(VatLayerExternalSearchProvider)}", TimeSpan.Zero).GetAwaiter().GetResult())
             {
-                executionContext.Log.LogDebug($"Sleeping thread for 1000ms due to TooManyRequest response received");
-                Thread.Sleep(1000);
+                executionContext.Log.LogDebug($"Sleeping thread for {delay.TotalSeconds:0} seconds due to TooManyRequest response received");
+                Thread.Sleep(delay);
             }
         }
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48974](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48974)

Seem like VatLayer API is having newly implemented rate limit (number of calls per seconds), but the limit is not found in documentation. Adding the retry with PrivateServices locks

Depend on: https://github.com/CluedIn-io/CluedIn/pull/7255

## How has it been tested? <!-- Remove if not needed -->
Manually in local
