### PR TITLE
chore: Update CluedIn version to 4.7.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Dependency Versions">
     <_ComponentHost>3.2.1</_ComponentHost>
     <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_CluedIn>4.7.0-alpha.*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--

--- a/docs/4.7.0-release-notes.md
+++ b/docs/4.7.0-release-notes.md
@@ -1,6 +1,7 @@
 # Feature
-- Supports enricherv2
 
 # Fix
-- Set Accepted Vocabulary Key as mandatory
 - Retry requests when rate limit is hit
+
+# Chore
+- Update to support CluedIn 4.7.0


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

The `Retry requests when rate limit is hit` changes is not in master branch, seem like the merging got messed up. So I am including the fix in 4.7.0 release note

## How has it been tested? <!-- Remove if not needed -->
Manually in local

