### PR TITLE
fix: Fix code generation in PopulateMetadata

### DIFF
--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,0 +1,2 @@
+# Fixes
+- Fix code generation by retrieving the exact query key for code generation in PopulateMetadata

--- a/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.VatLayer/VatLayerExternalSearchProvider.cs
@@ -332,7 +332,7 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
             {
                 var resultItem = result.As<VatLayerResponse>();
                 var dirtyClue = request.CustomQueryInput.ToString();
-                var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "vatlayer", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+                var code = new EntityCode(request.EntityMetaData.EntityType, "vatlayer", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
                 var clue = new Clue(code, context.Organization);
 
                 PopulateMetadata(clue.Data.EntityData, resultItem, request);
@@ -476,7 +476,8 @@ namespace CluedIn.ExternalSearch.Providers.VatLayer
 
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<VatLayerResponse> resultItem, IExternalSearchRequest request)
         {
-            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "vatlayer", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var queryKey = request.Queries.FirstOrDefault(x => x.Id == resultItem.QueryId)?.QueryKey ?? request.Queries.FirstOrDefault()?.QueryKey;
+            var code = new EntityCode(request.EntityMetaData.EntityType, "vatlayer", $"{queryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
 
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name;


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#57373](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57373)

Code generation should not always use first query key as there might be other provider enriching the entity.
This issue only affecting enricher V1 as V2 will generate code using hash in microservice

Screenshot from DuckDuckGo but the logic is the same
<img width="1936" height="1084" alt="image" src="https://github.com/user-attachments/assets/86df69fc-5d96-499e-b7c1-df7919eb3539" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local